### PR TITLE
add "-no-header" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,26 @@ A full list of binaries are [here](https://github.com/etsxxx/go-sitemap2csv/rele
 sitemap2csv <sitemap_url> <output_csv_file>
 ```
 
-You get a CSV file like the following.  
-The first record is a header row with "loc" and "lastmod".  
+You get a CSV file like the following.
+The first record is a header row with "loc" and "lastmod".
 "lastmod" is empty if there is no lastmod value.
 
 ```text
 loc,lastmod
+https://example.com/foo,
+https://example.com/bar,2025-05-22T01:02:03.000Z
+https://example.com/baz,
+```
+
+If you don't need header row, add '-no-header' option.
+
+```bash
+sitemap2csv -no-header <sitemap_url> <output_csv_file>
+```
+
+With '-no-header' option, you get a CSV file like the following.
+
+```text
 https://example.com/foo,
 https://example.com/bar,2025-05-22T01:02:03.000Z
 https://example.com/baz,

--- a/cmd/sitemap2csv/main.go
+++ b/cmd/sitemap2csv/main.go
@@ -67,7 +67,7 @@ func main() {
 	}()
 	w := csv.NewWriter(f)
 	records := result.Records
-	if noHeader && len(records) > 1 {
+	if noHeader && len(records) > 0 {
 		records = records[1:]
 	}
 	if err := w.WriteAll(records); err != nil {

--- a/cmd/sitemap2csv/main.go
+++ b/cmd/sitemap2csv/main.go
@@ -15,11 +15,13 @@ func main() {
 	var (
 		showVersion bool
 		showHelp    bool
+		noHeader    bool
 	)
 	flag.BoolVar(&showVersion, "v", false, "show version")
 	flag.BoolVar(&showVersion, "version", false, "show version")
 	flag.BoolVar(&showHelp, "h", false, "show help")
 	flag.BoolVar(&showHelp, "help", false, "show help")
+	flag.BoolVar(&noHeader, "no-header", false, "output CSV without header row")
 	flag.Usage = func() {
 		fmt.Println("Usage: sitemap2csv [options] <sitemap_url> <output_csv_file>")
 		flag.PrintDefaults()
@@ -64,7 +66,11 @@ func main() {
 		}
 	}()
 	w := csv.NewWriter(f)
-	if err := w.WriteAll(result.Records); err != nil {
+	records := result.Records
+	if noHeader && len(records) > 1 {
+		records = records[1:]
+	}
+	if err := w.WriteAll(records); err != nil {
 		fmt.Fprintf(os.Stderr, "Error writing CSV: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/sitemap2csv/main.go
+++ b/cmd/sitemap2csv/main.go
@@ -67,7 +67,9 @@ func main() {
 	}()
 	w := csv.NewWriter(f)
 	records := result.Records
-	if noHeader && len(records) > 0 {
+	if noHeader && len(records) >= 1 {
+		// If noHeader is true, remove the header row from the records
+		// This assumes the first row is the header
 		records = records[1:]
 	}
 	if err := w.WriteAll(records); err != nil {


### PR DESCRIPTION
For systematic use, CSV header is not required, so an option "-no-header" is added.